### PR TITLE
Fixes issue with player_position by fully resetting player's transform

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -48,7 +48,7 @@ func _on_FadeToBlack_finished_fading():
 				current_world = null
 			
 			# Position our player in the center
-			$OVRFirstPerson.position_player(Transform())
+			$OVRFirstPerson.global_transform = Transform()
 			
 			# Disable our functions
 			$OVRFirstPerson.enable_locomotion = false


### PR DESCRIPTION
The player_position() method only works the first time in the demo.  If you load a scene again you will not spawn where you expect.  See https://github.com/zombieCraig/godot_background_loading/tree/position_test for a demo of the issue.

I've placed the center menu behind the boxes.  And if you move in position to click the button it will attempt to load the same level which should start you in the same place but it won't.

Turns out this was a bug in FADE_TO_BLACK_1 transition state.  The $OVRFirstPerson global transform wasn't being reset properly.